### PR TITLE
Typo and specify SDK folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Step 3. Add the following to the settings.gradle file:
 
 ```
 include ':sitewhere-android-sdk'
-project(':sitewhere-android-sdk').projectDir = new File('../sitewhere-android-sdk') // <- points to the local repository 
+project(':sitewhere-android-sdk').projectDir = new File('../sitewhere-android-sdk') // <- points to the 'sitewhere-android-sdk' folder inside local repository cloned in Step 1 
 ```
-Step 4. Select "Open Model Settings" and add model "sitewhere-android-sdk" in the Dependencies tab.
+Step 4. Select "Open Module Settings" and add module "sitewhere-android-sdk" in the Dependencies tab.
 
 # Sample Application
 The sample app can be found in the SiteWhereExample folder.  The app demostrates how an Android device can be an IoT gateway and/or client device for SiteWhere.  As an IoT gateway you can register an Android device with SiteWhere and send location and measurement events.  As an IoT client you can register to have events pushed in real-time to an Android device.  Configuring what events get pushed to a specific device is done using server side filters and groovy scripts.  The sample app uses the device's current location and accelerometer.


### PR DESCRIPTION
Typo: "Open Model Settings" -> "Open Module Settings"
Typo: " and add model" -> " and add module"

Step 3 was not clear enough. If "settings.gradle" points to local repository instead 'sitewhere-android-sdk' folder inside local repository, causes "Configuration with name 'default' not found" error.